### PR TITLE
fix: auto-merge formula PR directly instead of using --auto

### DIFF
--- a/.github/workflows/update-last9-mcp.yml
+++ b/.github/workflows/update-last9-mcp.yml
@@ -90,9 +90,8 @@ jobs:
           delete-branch: true
           labels: automated-pr, dependencies
 
-      - name: Enable Auto-merge
+      - name: Merge Pull Request
         if: steps.create-pr.outputs.pull-request-number
-        run: |
-          gh pr merge --auto --merge "${{ steps.create-pr.outputs.pull-request-number }}"
+        run: gh pr merge --merge "${{ steps.create-pr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ github.token }} 
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-last9-mcp.yml
+++ b/.github/workflows/update-last9-mcp.yml
@@ -92,6 +92,6 @@ jobs:
 
       - name: Merge Pull Request
         if: steps.create-pr.outputs.pull-request-number
-        run: gh pr merge --merge "${{ steps.create-pr.outputs.pull-request-number }}"
+        run: gh pr merge --merge --yes "${{ steps.create-pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- `gh pr merge --auto` requires branch protection with required checks — homebrew-tap has none, so auto-merge silently never fires
- Replace with `gh pr merge --merge` for direct immediate merge

## Test plan
- [ ] Trigger a release in last9-mcp-server and verify the formula PR gets created and auto-merged