### PR TITLE
fix: remove --yes flag from gh pr merge

### DIFF
--- a/.github/workflows/update-last9-mcp.yml
+++ b/.github/workflows/update-last9-mcp.yml
@@ -92,6 +92,6 @@ jobs:
 
       - name: Merge Pull Request
         if: steps.create-pr.outputs.pull-request-number
-        run: gh pr merge --merge --yes "${{ steps.create-pr.outputs.pull-request-number }}"
+        run: gh pr merge --merge "${{ steps.create-pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
`--yes` flag does not exist in `gh pr merge`. Likely never existed in official CLI docs — confirmed against https://cli.github.com/manual/gh_pr_merge.

`gh pr merge --merge <number>` is already non-interactive when a PR number is supplied. No skip-prompt flag needed.

Fixes the failing scheduled workflow run.